### PR TITLE
Updated LootMgr

### DIFF
--- a/src/game/Entities/Item.cpp
+++ b/src/game/Entities/Item.cpp
@@ -692,6 +692,12 @@ uint32 Item::GetSpell() const
 
 int32 Item::GenerateItemRandomPropertyId(uint32 item_id)
 {
+    uint32 suffixvalue;
+    return GenerateItemRandomPropertyId(item_id, suffixvalue);
+}
+
+int32 Item::GenerateItemRandomPropertyId(uint32 item_id, uint32& suffixvalue)
+{
     ItemPrototype const* itemProto = sItemStorage.LookupEntry<ItemPrototype>(item_id);
 
     if (!itemProto)
@@ -704,7 +710,7 @@ int32 Item::GenerateItemRandomPropertyId(uint32 item_id)
     // Random Property case
     if (itemProto->RandomProperty)
     {
-        uint32 randomPropId = GetItemEnchantMod(itemProto->RandomProperty);
+        uint32 randomPropId = GetItemEnchantMod(itemProto->RandomProperty, suffixvalue);
         ItemRandomPropertiesEntry const* random_id = sItemRandomPropertiesStore.LookupEntry(randomPropId);
         if (!random_id)
         {

--- a/src/game/Entities/Item.h
+++ b/src/game/Entities/Item.h
@@ -321,9 +321,10 @@ class Item : public Object
         void SetItemRandomProperties(int32 randomPropId);
         void UpdateItemSuffixFactor();
         static int32 GenerateItemRandomPropertyId(uint32 item_id);
+        static int32 GenerateItemRandomPropertyId(uint32 item_id, uint32& suffixvalue);
 
 		static uint32 LoadScaledLoot(uint32 ItemId, Player* pPlayer, bool upgrade = false);
-		static uint32 LoadScaledLoot(uint32 ItemId, uint32 plevel, bool upgrade = false, Player* pPlayer = nullptr );
+		static uint32 LoadScaledLoot(uint32 ItemId, uint32 plevel, bool upgrade = false, Player* pPlayer = nullptr);
 		static uint32 LoadScaledParent(uint32 ItemId);
 		static uint32 ComputeRequiredLevel(uint32 quality, uint32 ilevel);
 

--- a/src/game/Entities/ItemEnchantmentMgr.h
+++ b/src/game/Entities/ItemEnchantmentMgr.h
@@ -23,5 +23,6 @@
 
 void LoadRandomEnchantmentsTable();
 uint32 GetItemEnchantMod(uint32 entry);
+uint32 GetItemEnchantMod(uint32 entry, uint32& suffixvalue);
 uint32 GenerateEnchSuffixFactor(uint32 item_id);
 #endif

--- a/src/game/Loot/LootMgr.h
+++ b/src/game/Loot/LootMgr.h
@@ -200,7 +200,8 @@ struct LootItem
     bool         isUnderThreshold  : 1;
     bool         currentLooterPass : 1;
     bool         isReleased        : 1;                             // true if item is released by looter or by roll system
-	bool         isScaled          = false;                         // true if item is scaled
+    uint32       loot_level;
+    uint32       suffixvalue;
     std::map<uint32, uint32> randomPropertyIdArray;
     std::map<uint32, uint32> randomSuffixIdArray;
 
@@ -211,13 +212,12 @@ struct LootItem
     // Should be called for non-reference LootStoreItem entries only (mincountOrRef > 0)
     explicit LootItem(LootStoreItem const& li, uint32 _lootSlot, uint32 threshold);
 
-    LootItem(uint32 _itemId, uint32 _count, uint32 _randomSuffix, int32 _randomPropertyId, uint32 _lootSlot);
+    LootItem(uint32 _itemId, uint32 _count, uint32 _randomSuffix, int32 _randomPropertyId, uint32 _lootSlot, uint32 suffixvalue = 0);
 
 	int32 getRandomPropertyScaled(uint32 ilevel, bool won = false, bool display = true);
 	void setRandomPropertyScaled();
 	int32 getRandomSuffixScaled(uint32 ilevel, bool won = false, bool display = true);
 	void setRandomSuffixScaled();
-	uint32 loot_level = 0;
 
     // Basic checks for player/item compatibility - if false no chance to see the item in the loot
     bool AllowedForPlayer(Player const* player, WorldObject const* lootTarget) const;


### PR DESCRIPTION
- implemented suffixvalue for ItemRandomPropertyId
- fixed group loot roll (level, randomproperty)
- fixed loot level using getAreaZoneLevel()
- removed deprecated vars